### PR TITLE
[codex] Add TIL on Git ignore levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
 
 * [Github Markdown API](https://git.gvoserver1.com/jnellis/Today-I-Learned/src/branch/main/github/markdown.md) - 2025-01-08
 * [Bulk Update Remote Origin](https://git.gvoserver1.com/jnellis/Today-I-Learned/src/branch/main/github/update_remote.md) - 2025-01-22
+* [Git Ignore Rules Can Live Outside .gitignore](https://git.gvoserver1.com/jnellis/Today-I-Learned/src/branch/main/github/git_ignore_levels.md) - 2026-06-21
 
 ## AWS
 

--- a/github/git_ignore_levels.md
+++ b/github/git_ignore_levels.md
@@ -1,0 +1,40 @@
+# Git Ignore Rules Can Live Outside .gitignore
+
+I used to treat `.gitignore` as *the* ignore file in Git. It is really just the shared, version-controlled layer. Git also has repo-local and user-global ignore files, which are useful for different kinds of noise.
+
+The practical split:
+
+- `.gitignore`: committed with the repo. Use it for generated files everyone working on the project should ignore.
+- `.git/info/exclude`: local to one clone. Use it for one-off files that are only part of my workflow in that repo.
+- `~/.config/git/ignore`: the default global ignore file. Use it for machine-wide junk like `.DS_Store`.
+
+The global location can be overridden:
+
+```shell
+git config --global core.excludesFile ~/.gitignore_global
+```
+
+Unset the override to go back to the default:
+
+```shell
+git config --global --unset core.excludesFile
+```
+
+The best debugging command is:
+
+```shell
+git check-ignore -v .DS_Store
+```
+
+The `-v` output tells you the source file, line number, pattern, and path that matched. That makes it a quick way to answer: "which ignore rule is responsible for this?"
+
+One extra gotcha: ignore rules apply to intentionally untracked files. If a file is already tracked, adding it to an ignore file will not make Git stop tracking it. Remove it from the index first, for example:
+
+```shell
+git rm --cached path/to/file
+```
+
+References:
+
+- [gitignore documentation](https://git-scm.com/docs/gitignore)
+- [git check-ignore documentation](https://git-scm.com/docs/git-check-ignore)


### PR DESCRIPTION
## What changed

- Added a new GitHub TIL post about the three practical ignore scopes in Git: `.gitignore`, `.git/info/exclude`, and the global ignore file.
- Updated the README index so the new post appears under the `github` topic.

## Notes

- The post is original prose based on the requested topic and links to the official Git documentation for `gitignore` and `git check-ignore`.
- I could not run `build_database.py` in the local shell because this environment cannot clone the repo from GitHub, so `tils.db` was not regenerated in this branch.

## Validation

- Verified the new Markdown file via the GitHub contents API.
- Verified the README index entry via the GitHub contents API.
- Compared the branch against `main`: 2 files changed, 40 additions in the new post, and the README index updated.